### PR TITLE
Add Docker-based MCP toolkit connector

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -61,7 +61,20 @@ The client will test both stdio and HTTP transports. For the best experience:
    - Start the HTTP server: `python mcp/mcp_server.py --transport streamable-http --port 8000`
    - Return to the first terminal and press Enter to continue
 
-### 3. Testing with MCP Inspector
+### 3. Connecting to a Dockerized MCP Toolkit
+
+If you have a Docker-based MCP toolkit that exposes many MCP servers on a single TCP port,
+the client can connect through a `socat` bridge. The client automatically launches a Docker
+container to pipe STDIO to the toolkit's TCP endpoint.
+
+```bash
+python mcp/mcp_client.py --host host.docker.internal --port 8811 --docker-image alpine/socat --list-tools
+```
+
+You can modify the host, port, or Docker image using the `--host`, `--port`, and
+`--docker-image` options. Use `--tool <tool_name>` to call a specific tool after listing.
+
+### 4. Testing with MCP Inspector
 
 You can also test the server using the built-in MCP inspector:
 

--- a/mcp/mcp_client.py
+++ b/mcp/mcp_client.py
@@ -1,10 +1,18 @@
 import asyncio
 import json
+import os
+import argparse
 from typing import Optional
 
 from mcp import ClientSession, StdioServerParameters, types
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamablehttp_client
+
+
+# Default configuration values for the Docker-based MCP bridge
+DEFAULT_DOCKER_IMAGE = os.getenv("MCP_DOCKER_IMAGE", "alpine/socat")
+DEFAULT_MCP_HOST = os.getenv("MCP_HOST", "host.docker.internal")
+DEFAULT_MCP_PORT = int(os.getenv("MCP_PORT", "8811"))
 
 
 async def handle_sampling_message(
@@ -22,15 +30,31 @@ async def handle_sampling_message(
     )
 
 
-async def demo_stdio_client():
-    """Demonstrate MCP client using stdio transport."""
+async def demo_stdio_client(
+    host: str = DEFAULT_MCP_HOST,
+    port: int = DEFAULT_MCP_PORT,
+    docker_image: str = DEFAULT_DOCKER_IMAGE,
+    tool_name: Optional[str] = None,
+    list_only: bool = False,
+):
+    """Connect to the MCP toolkit using a Docker-based stdio bridge."""
     print("=== MCP Stdio Client Demo ===")
-    
+
+    # Build docker command for socat bridge
+    docker_args = [
+        "run",
+        "-i",
+        "--rm",
+        docker_image,
+        "STDIO",
+        f"TCP:{host}:{port}",
+    ]
+
     # Create server parameters for stdio connection
     server_params = StdioServerParameters(
-        command="python",  # Executable
-        args=["mcp/mcp_server.py"],  # Server script
-        env=None,  # Optional environment variables
+        command="docker",
+        args=docker_args,
+        env=None,
     )
 
     try:
@@ -69,6 +93,7 @@ async def demo_stdio_client():
 
                 # List available tools
                 print("\n--- Listing Tools ---")
+                tools = None
                 try:
                     tools = await session.list_tools()
                     if tools.tools:
@@ -79,59 +104,37 @@ async def demo_stdio_client():
                 except Exception as e:
                     print(f"Error listing tools: {e}")
 
-                # Try to get a prompt (if available)
-                if prompts.prompts:
-                    try:
-                        prompt_name = prompts.prompts[0].name
-                        print(f"\n--- Getting Prompt: {prompt_name} ---")
-                        prompt_args = {}
-                        if prompts.prompts[0].arguments:
-                            # Simple example args
-                            for arg in prompts.prompts[0].arguments:
-                                if arg.required:
-                                    prompt_args[arg.name] = "example_value"
-                        
-                        prompt_result = await session.get_prompt(prompt_name, arguments=prompt_args)
-                        print(f"Prompt result: {prompt_result.description}")
-                        for msg in prompt_result.messages:
-                            print(f"  Message: {msg.content}")
-                    except Exception as e:
-                        print(f"Error getting prompt: {e}")
+                if list_only:
+                    return
 
-                # Try to read a resource (if available)
-                if resources.resources:
-                    try:
-                        resource_uri = resources.resources[0].uri
-                        print(f"\n--- Reading Resource: {resource_uri} ---")
-                        content, mime_type = await session.read_resource(resource_uri)
-                        print(f"Resource content (type: {mime_type}): {content[:200]}...")
-                    except Exception as e:
-                        print(f"Error reading resource: {e}")
+                # Determine which tool to call
+                selected_tool_name = tool_name
+                if not selected_tool_name and tools and tools.tools:
+                    selected_tool_name = tools.tools[0].name
 
-                # Try to call a tool (if available)
-                if tools.tools:
-                    try:
-                        tool_name = tools.tools[0].name
-                        print(f"\n--- Calling Tool: {tool_name} ---")
-                        
-                        # Simple example arguments
-                        tool_args = {}
-                        if hasattr(tools.tools[0], 'inputSchema') and tools.tools[0].inputSchema:
-                            # For demo purposes, provide simple default values
-                            schema = tools.tools[0].inputSchema
-                            if 'properties' in schema:
-                                for prop_name, prop_def in schema['properties'].items():
-                                    if prop_def.get('type') == 'string':
+                # Call the selected tool
+                if selected_tool_name:
+                    print(f"\n--- Calling Tool: {selected_tool_name} ---")
+
+                    tool_args = {}
+                    if tools and tools.tools:
+                        selected = next((t for t in tools.tools if t.name == selected_tool_name), None)
+                        if selected and getattr(selected, "inputSchema", None):
+                            schema = selected.inputSchema
+                            if "properties" in schema:
+                                for prop_name, prop_def in schema["properties"].items():
+                                    if prop_def.get("type") == "string":
                                         tool_args[prop_name] = "example"
-                                    elif prop_def.get('type') == 'integer':
+                                    elif prop_def.get("type") == "integer":
                                         tool_args[prop_name] = 42
-                                    elif prop_def.get('type') == 'number':
+                                    elif prop_def.get("type") == "number":
                                         tool_args[prop_name] = 3.14
-                        
-                        result = await session.call_tool(tool_name, arguments=tool_args)
+
+                    try:
+                        result = await session.call_tool(selected_tool_name, arguments=tool_args)
                         print(f"Tool result: {result.content}")
                     except Exception as e:
-                        print(f"Error calling tool: {e}")
+                        print(f"Error calling tool '{selected_tool_name}': {e}")
 
     except Exception as e:
         print(f"Stdio client error: {e}")
@@ -207,33 +210,28 @@ async def demo_http_client(server_url: str = "http://localhost:8000/mcp"):
 
 
 async def main():
-    """Main function demonstrating both stdio and HTTP MCP clients."""
-    print("MCP Client Examples")
-    print("==================")
-    print()
-    print("This demo will test both stdio and HTTP transports.")
-    print("For stdio: The server will be started automatically.")
-    print("For HTTP: You need to start the server manually in another terminal.")
-    print()
-    
-    # Demo stdio client
-    print("1. Testing stdio transport...")
-    await demo_stdio_client()
-    
-    # Demo HTTP client
-    print("\n" + "="*50)
-    print("2. Testing HTTP transport...")
-    print("NOTE: For HTTP testing, start the server in another terminal with:")
-    print("  python mcp/mcp_server.py --transport streamable-http --port 8000")
-    print("Then press Enter to continue, or Ctrl+C to skip HTTP testing.")
-    
-    try:
-        input()  # Wait for user to press Enter
-        await demo_http_client()
-    except KeyboardInterrupt:
-        print("\nSkipping HTTP transport test.")
-    
-    print("\nMCP Client demo completed!")
+    """Entry point for connecting to the MCP toolkit."""
+    parser = argparse.ArgumentParser(description="Connect to a Docker-hosted MCP toolkit")
+    parser.add_argument("--host", default=DEFAULT_MCP_HOST, help="Toolkit host")
+    parser.add_argument("--port", type=int, default=DEFAULT_MCP_PORT, help="Toolkit port")
+    parser.add_argument("--docker-image", default=DEFAULT_DOCKER_IMAGE, help="Docker image for socat bridge")
+    parser.add_argument("--list-tools", action="store_true", help="List available tools and exit")
+    parser.add_argument("--tool", help="Call a specific tool by name")
+    parser.add_argument("--http-url", help="Optional HTTP server URL for testing")
+
+    args = parser.parse_args()
+
+    if args.http_url:
+        await demo_http_client(server_url=args.http_url)
+        return
+
+    await demo_stdio_client(
+        host=args.host,
+        port=args.port,
+        docker_image=args.docker_image,
+        tool_name=args.tool,
+        list_only=args.list_tools,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- configure MCP client connection through Docker `socat` bridge
- support selecting tools and listing tools by name
- make Docker image, host and port configurable via CLI and env vars
- document connecting to a Dockerized MCP toolkit

## Testing
- `python run_tests.py all` *(fails: ImportError: cannot import name 'Undefined' from 'pydantic.fields')*

------
https://chatgpt.com/codex/tasks/task_b_6850a0d0c8e88328916edb55bf7ffd65